### PR TITLE
Add prefix to lambda locals to avoid name conflicts

### DIFF
--- a/lib/definitions/redefiner.rb
+++ b/lib/definitions/redefiner.rb
@@ -111,11 +111,19 @@ module LowType
               __low_type_position = nil unless [:opt, :req, :rest].include?(__low_type_type)
               __low_type_expression = binding.local_variable_get(__low_type_name)
 
-              if __low_type_expression.is_a?(TypeExpression)
-                __low_type_param_proxies << ParamProxy.new(type_expression: __low_type_expression, name: __low_type_name, type: __low_type_type, position: __low_type_position, file: __low_type_file)
+              __low_type_expression = if __low_type_expression.is_a?(TypeExpression)
+                __low_type_expression
               elsif ::LowType::TypeQuery.type?(__low_type_expression)
-                __low_type_param_proxies << ParamProxy.new(type_expression: TypeExpression.new(type: __low_type_expression), name: __low_type_name, type: __low_type_type, position: __low_type_position, file: __low_type_file)
+                TypeExpression.new(type: __low_type_expression)
               end
+
+              __low_type_param_proxies << ParamProxy.new(
+                type_expression: __low_type_expression,
+                name: __low_type_name,
+                type: __low_type_type,
+                position: __low_type_position,
+                file: __low_type_file
+              )
             end
 
             __low_type_param_proxies


### PR DESCRIPTION
This pull request fixes an issue where local variables would conflict with parameter names LowType is attempting to proxy.

It refactors the `param_proxies` method in `lib/definitions/redefiner.rb` to improve variable naming and prevent conflicts with method parameters. The main change is the introduction of a naming convention for local variables within the dynamically generated method, ensuring they are prefixed to avoid clashes.

Variable naming and conflict prevention:

* All local variables inside the dynamically generated method are now prefixed with `__low_type_` to avoid naming conflicts with method parameters.
* The dynamically generated method signature now explicitly includes `__low_type_proxy_method` and `__low_type_file` as parameters, and these are passed when invoking the method to ensure correct context and avoid conflicts.

Functionality preservation:

* The logic for collecting parameter proxies remains the same, but all variable references inside the method have been updated to use the new prefixed names.

## Origin of the issue

Assume app code:

```ruby
class User
  include LowType

  def initialize(name = String)
    @name = name
  end
end
```

When instantiating this class and assigning an invalid value for `name`, a TypeError is not generated as expected.

```ruby
irb(main):001> require "low_type"
irb(main):002> require_relative "user"
=> true
irb(main):003> User.new(12)
=> #<User:0x0000000129730648 @name=12>
irb(main):004>
```

LowType should not allow the initialization of a User with an Integer name.

## Cause of the bug

Creating the `ParamProxy`s is done in a lambda with its own local variables. If one of those local variable names conflict with a param name being passed in, the newly assigned local var will replace it. Then, the call to `expression = binding.local_variable_get(name)` will assign the incorrect value to `expression`.

This bug was initially apparent with a method parameter named `name`, but it would occur on any method parameter named `type`, `name`, `position`, `expression`, etc.


