### PR TITLE
Prevent parsing non existing files

### DIFF
--- a/lib/low_type.rb
+++ b/lib/low_type.rb
@@ -21,6 +21,8 @@ module LowType
     end
 
     file_path = FileQuery.file_path(klass:)
+    return unless File.exist?(file_path)
+
     parser = FileParser.new(klass:, file_path:)
 
     klass.extend TypeAccessors


### PR DESCRIPTION
Running this little snippet on my machine:
```
irb(main):001> require 'low_type'
=> true
irb(main):002* class MyClass
irb(main):003*   include LowType
irb(main):004> end
```

Gave me the following error:
```
/Users/bn/.asdf/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/low_type-1.1.3/lib/queries/file_parser.rb:11:in 'Prism.parse_file': No such file or directory - (irb) (Errno::ENOENT)
        from /Users/bn/.asdf/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/low_type-1.1.3/lib/queries/file_parser.rb:11:in 'LowType::FileParser#initialize'
        from /Users/bn/.asdf/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/low_type-1.1.3/lib/low_type.rb:24:in 'Class#new'
        from /Users/bn/.asdf/installs/ruby/3.4.4/lib/ruby/gems/3.4.0/gems/low_type-1.1.3/lib/low_type.rb:24:in 'LowType.included'
        from (irb):3:in 'Module#include'
        from (irb):3:in '<class:MyClass>'
        from (irb):2:in '<main>'
```
My guess is that LowType fails because it tries to parse the virtual file which doesn't exist on disk. So my suggestion is to add a condition to check whether the file path provided actually exists. If not, then do not attempt to parse it. I tried this out locally and it worked well.

Let me know what you think!