### PR TITLE
fix: use is_a? for type matching to support subclass inheritance

### DIFF
--- a/lib/expressions/type_expression.rb
+++ b/lib/expressions/type_expression.rb
@@ -131,7 +131,7 @@ module Low
       if type.instance_of?(Class)
         return type.match?(value:) if Low::TypeQuery.complex_type?(expression: type)
 
-        return type == value.class
+        return value.is_a?(type)
       elsif type.instance_of?(::Low::TypeExpression)
         type.validate!(value:, proxy:)
         return true

--- a/spec/features/inheritance_spec.rb
+++ b/spec/features/inheritance_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require_relative '../fixtures/inheritance'
+
+RSpec.describe 'Subclass type inheritance' do
+  # Test plan item 1: Subclass instance accepted for parent type
+  context 'direct subclass (Dog for Animal)' do
+    subject(:kennel) { Kennel.new }
+
+    it 'accepts the exact type' do
+      expect(kennel.admit(pet: Animal.new)).to eq('Welcome, Animal!')
+    end
+
+    it 'accepts a subclass instance without raising' do
+      expect { kennel.admit(pet: Dog.new) }.not_to raise_error
+    end
+
+    it 'returns the correct greeting for the subclass' do
+      expect(kennel.admit(pet: Dog.new)).to eq('Welcome, Dog!')
+    end
+  end
+
+  # Test plan item 2: Multi-level inheritance
+  context 'multi-level inheritance (GoldenRetriever < Dog < Animal)' do
+    subject(:kennel) { Kennel.new }
+
+    it 'accepts a grandchild subclass instance without raising' do
+      expect { kennel.admit(pet: GoldenRetriever.new) }.not_to raise_error
+    end
+
+    it 'returns the correct greeting for the grandchild subclass' do
+      expect(kennel.admit(pet: GoldenRetriever.new)).to eq('Welcome, GoldenRetriever!')
+    end
+  end
+
+  # Test plan item 3: Core Ruby hierarchies
+  context 'core Ruby hierarchy (Integer for Numeric)' do
+    subject(:box) { NumericBox.new }
+
+    it 'accepts an Integer for a Numeric parameter' do
+      expect { box.store(value: 42) }.not_to raise_error
+    end
+
+    it 'accepts a Float for a Numeric parameter' do
+      expect { box.store(value: 3.14) }.not_to raise_error
+    end
+
+    it 'rejects a non-Numeric value' do
+      expect { box.store(value: 'not a number') }.to raise_error(Low::ArgumentTypeError)
+    end
+  end
+
+  context 'core Ruby hierarchy (File for IO)' do
+    subject(:reader) { IOReader.new }
+
+    it 'accepts a File instance for an IO parameter' do
+      file = File.open(__FILE__, 'r')
+      expect { reader.read(source: file) }.not_to raise_error
+      file.close
+    end
+  end
+
+  # Test plan item 4: No regressions — wrong type still raises
+  context 'regression: unrelated type still raises' do
+    subject(:kennel) { Kennel.new }
+
+    it 'raises Low::ArgumentTypeError for a completely unrelated type' do
+      expect { kennel.admit(pet: 'not an animal') }.to raise_error(Low::ArgumentTypeError)
+    end
+
+    it 'raises Low::ArgumentTypeError for an Integer' do
+      expect { kennel.admit(pet: 42) }.to raise_error(Low::ArgumentTypeError)
+    end
+  end
+end

--- a/spec/features/inheritance_spec.rb
+++ b/spec/features/inheritance_spec.rb
@@ -35,25 +35,25 @@ RSpec.describe 'Subclass type inheritance' do
 
   # Test plan item 3: Core Ruby hierarchies
   context 'core Ruby hierarchy (Integer for Numeric)' do
-    subject(:box) { NumericBox.new }
+    subject(:store) { NumericStore.new }
 
     it 'accepts an Integer for a Numeric parameter' do
-      expect { box.store(value: 42) }.not_to raise_error
+      expect { store.save(value: 42) }.not_to raise_error
     end
 
     it 'accepts a Float for a Numeric parameter' do
-      expect { box.store(value: 3.14) }.not_to raise_error
+      expect { store.save(value: 3.14) }.not_to raise_error
     end
 
     it 'rejects a non-Numeric value' do
-      expect { box.store(value: 'not a number') }.to raise_error(Low::ArgumentTypeError)
+      expect { store.save(value: 'not a number') }.to raise_error(Low::ArgumentTypeError)
     end
   end
 
-  context 'core Ruby hierarchy (File for IO)' do
+  context 'when reading a file' do
     subject(:reader) { IOReader.new }
 
-    it 'accepts a File instance for an IO parameter' do
+    it 'accepts a File instance arg for an IO typed parameter (File is a subclass of IO)' do
       file = File.open(__FILE__, 'r')
       expect { reader.read(source: file) }.not_to raise_error
       file.close

--- a/spec/fixtures/inheritance.rb
+++ b/spec/fixtures/inheritance.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative '../../lib/low_type'
+
+class Animal; end
+class Dog < Animal; end
+class GoldenRetriever < Dog; end
+
+class Kennel
+  include LowType
+
+  def admit(pet: Animal)
+    "Welcome, #{pet.class}!"
+  end
+end
+
+class NumericBox
+  include LowType
+
+  def store(value: Numeric)
+    value
+  end
+end
+
+class IOReader
+  include LowType
+
+  def read(source: IO)
+    source.class.name
+  end
+end

--- a/spec/fixtures/inheritance.rb
+++ b/spec/fixtures/inheritance.rb
@@ -14,10 +14,10 @@ class Kennel
   end
 end
 
-class NumericBox
+class NumericStore
   include LowType
 
-  def store(value: Numeric)
+  def save(value: Numeric)
     value
   end
 end


### PR DESCRIPTION
## Summary
Fixes type checking to correctly support subclass instances.

## Problem
The current implementation uses strict class equality:

type == value.class

This rejects valid subclass instances, even though they satisfy the type contract via inheritance.

For example:
- Dog is rejected for Animal
- Integer/Float for Numeric
- File for IO

## Solution
Replaced strict equality with Ruby's idiomatic type check:

value.is_a?(type)

This aligns with Ruby's type system and expected behavior.

## Test Coverage
Added comprehensive tests to validate the fix:

- Subclass instances are accepted (Dog for Animal)
- Multi-level inheritance is supported (GoldenRetriever < Dog < Animal)
- Core Ruby hierarchies:
  - Integer/Float for Numeric
  - File for IO
- Regression tests ensure invalid types still raise errors

All existing tests pass with no regressions.

## Impact
- Fixes incorrect type rejection for subclasses
- Improves compatibility with Ruby's object model
- Maintains backward compatibility

Closes #28