### PR TITLE
Fix Issue #35: hoist Config Struct to constant to avoid per-call allocation

### DIFF
--- a/lib/low_type.rb
+++ b/lib/low_type.rb
@@ -50,17 +50,18 @@ module LowType
     Low::Adapter::Loader.load(klass:, class_proxy:)
   end
 
+  Config = Struct.new(
+    :type_checking,
+    :error_mode,
+    :output_mode,
+    :output_size,
+    :deep_type_check,
+    :union_type_expressions
+  )
+
   class << self
     def config
-      config = Struct.new(
-        :type_checking,
-        :error_mode,
-        :output_mode,
-        :output_size,
-        :deep_type_check,
-        :union_type_expressions
-      )
-      @config ||= config.new(true, :error, :type, 100, true, true)
+      @config ||= Config.new(true, :error, :type, 100, true, true)
     end
 
     def configure


### PR DESCRIPTION
Fixes #35

## Change

Hoisted `Struct.new` out of the `config` method body into a constant
so the anonymous Struct class is allocated once at load time rather
than on every call to `LowType.config`.

## Before
Every `LowType.config` call allocated and discarded a new Struct class.

## After
Struct class is created once. `@config ||=` memoizes the instance as before.