### PR TITLE
Capture class binding via TracePoint :end

### DIFF
--- a/lib/low_type.rb
+++ b/lib/low_type.rb
@@ -31,7 +31,7 @@ require_relative 'types/complex_types'
 #      │              │                 │◄┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┤
 #      │              │                 │                 │               │
 module LowType
-  # We do as much as possible on class load rather than on object instantiation to be thread-safe and efficient.
+  # Defers evaluation and redefinition until after the class body finishes loading via TracePoint :end.
   def self.included(klass)
     file_path = Low::FileQuery.file_path(klass:)
     file_proxy = Lowkey.load(file_path)
@@ -43,8 +43,8 @@ module LowType
     klass.extend Low::Types
 
     # Use TracePoint :end to capture the class binding after the class body finishes loading.
-    # At :end time, trace.self is the including class and trace.binding is the class body's binding —
-    # stored on class_proxy.class_binding for use by LowType and other consumers (e.g. Evaluator, Redefiner).
+    # At :end time, trace.self is the including class and trace.binding is the class body's binding,
+    # stored on class_proxy.class_binding for use by LowType and other consumers.
     tp = TracePoint.new(:end) do |trace|
       next unless trace.self == klass
 

--- a/lib/low_type.rb
+++ b/lib/low_type.rb
@@ -37,17 +37,30 @@ module LowType
     file_proxy = Lowkey.load(file_path)
     class_proxy = file_proxy[klass.name]
 
-    Low::Evaluator.evaluate(method_proxies: class_proxy.keyed_methods)
-
     klass.include Low::ExpressionHelpers
     klass.extend Low::ExpressionHelpers
     klass.extend Low::TypeAccessors
     klass.extend Low::Types
 
-    klass.prepend Low::Redefiner.redefine(method_proxies: class_proxy.instance_methods, class_proxy:)
-    klass.singleton_class.prepend Low::Redefiner.redefine(method_proxies: class_proxy.class_methods, class_proxy:)
+    # Use TracePoint :end to capture the class binding after the class body finishes loading.
+    # At :end time, trace.self is the including class and trace.binding is the class body's binding —
+    # stored on class_proxy.class_binding for use by LowType and other consumers (e.g. Evaluator, Redefiner).
+    tp = TracePoint.new(:end) do |trace|
+      next unless trace.self == klass
 
-    Low::Adapter::Loader.load(klass:, class_proxy:)
+      class_proxy.class_binding = trace.binding
+
+      Low::Evaluator.evaluate(method_proxies: class_proxy.keyed_methods)
+
+      klass.prepend Low::Redefiner.redefine(method_proxies: class_proxy.instance_methods, class_proxy:)
+      klass.singleton_class.prepend Low::Redefiner.redefine(method_proxies: class_proxy.class_methods, class_proxy:)
+
+      Low::Adapter::Loader.load(klass:, class_proxy:)
+
+      tp.disable
+    end
+
+    tp.enable
   end
 
   class << self


### PR DESCRIPTION
## Summary

Wraps the class load phase in a `TracePoint :end` block so that 
evaluation and redefinition happen after the class body finishes 
loading. At `:end` time, `trace.binding` is captured and stored 
on `class_proxy.class_binding`.

## Context

This is the foundational PR. Two things it enables:

1. **Correct constant resolution** : user-defined constants like 
`PaymentMethod` are visible in the class body binding, fixing the 
`NameError` described in low-rb/low_type#31

2. **Method rewriting** : the method rewriting PR (which closes 
low-rb/low_type#38) builds directly on top of this

## Dependencies

Requires low-rb/lowkey#6 (merged) which adds `class_binding` 
as an `attr_accessor` on `ClassProxy`.

## Notes

- No method rewriting in this PR , foundational piece only
- Specs pass on `prototype/shim-rewrite` with this approach

closes #31 